### PR TITLE
feat: Automatic configuration of file system ACL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,48 +34,7 @@ If you do not configure this index, Splunk Connect for Kubernetes-OpenTelemetry 
 
 ## Setup for Non-Root User Group
 
-It is best practice to run pods as a non-root user. To avoid running collector pod as `root` user, perform below steps on each kubernetes nodes.
-
-In this chart, it is set to run as as a user with UID and GID of `10001` ([set here](https://github.com/splunk/sck-otel/blob/main/charts/sck-otel/values.yaml#L104)). But this user does not have the permission to read container log files typically owned by `root`. Below steps create a user with GID 10001 and grant access to that GID. 
-
-```bash
-# create a user otel with uid=10001 and gid=10001
-sudo adduser --disabled-password --uid 10001 --no-create-home otel
-
-# setup a directory for storing checkpoints
-sudo mkdir /var/lib/otel_pos
-sudo chgrp otel /var/lib/otel_pos
-sudo chmod g+rwx /var/lib/otel_pos
-
-# setup container log directories. 
-# To check where the files are, check symlinks file on `/var/log/pods/` and its target paths.
-ls -Rl /var/log/pods
-# default paths are these
-# `/var/lib/docker/containers` for docker 
-# `/var/log/crio/pods` for cri-o
-# `/var/log/pods` for containerd
-# add your container log path if different
-if [ -d "/var/lib/docker/containers" ] 
-then
-    sudo chgrp -R otel /var/lib/docker/containers
-    sudo chmod -R g+rwx /var/lib/docker/containers
-    sudo setfacl -Rm d:g:otel:rwx,g:otel:rwx /var/lib/docker/containers
-fi
-
-if [ -d "/var/log/crio/pods" ] 
-then
-    sudo chgrp -R otel /var/log/crio/pods
-    sudo chmod -R g+rwx /var/log/crio/pods
-    sudo setfacl -Rm d:g:otel:rwx,g:otel:rwx /var/log/crio/pods
-fi
-
-if [ -d "/var/log/pods" ] 
-then
-    sudo chgrp -R otel /var/log/pods
-    sudo chmod -R g+rwx /var/log/pods
-    sudo setfacl -Rm d:g:otel:rwx,g:otel:rwx /var/log/pods
-fi
-```
+It is best practice to run pods as a non-root user. To avoid running collector pod as `root` user this chart will modify the facl of /var/log to permit the groupid `20000` read and execute. 
 
 ## Deploy with Helm 3.0+
 

--- a/charts/sck-otel/values.yaml
+++ b/charts/sck-otel/values.yaml
@@ -93,7 +93,6 @@ containers:
 #    - containerName: buttercup-app
 #      first_entry_regex: "^.+Exception[^\n]++(\s+at.*)+"
 
-
 # List of key/value pairs for metadata purpose.
 # Can be used to define things such as cloud_account_id, cloud_account_region, etc.
 customMetadata: {}
@@ -127,10 +126,16 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podSecurityContext:
-  runAsUser: 10001
-  runAsGroup: 10001
-securityContext: {}
+podSecurityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsGroup: 20000
+  runAsUser: 20000
+  # capabilities:
+  #   add:
+  #     - CAP_AUDIT_READ
+  #     - CAP_DAC_READ_SEARCH
+
 podAnnotations: {}
 
 nodeSelector: {}


### PR DESCRIPTION
This feature ensures the otel container will have read access to `/var/log` while running in nonroot mode by default. It also ensures the container will have rw access to its checkpoint directory. 
Fixes #47 

Whats new:
* Use FS ACL rather than chown to append the new user/group to file system permissions this is safer as a patch/update on the node is less likely to undo it.
* Apply the guidance originally provided in README.md as an init container so its always applied in the case of node scale out
* Change the UID/GID to one that is not the most common example on the internet.

Alternatives considered:
* Do nothing: Keep the changes required for the node as customer responsibility. Customer feedback was consistent this wasn't a desirable outcome.
* Kind: JOB Can't ensure run once per node
* Run container as root by default. While this would work its not needed and could have consequences.
