### PR TITLE
Sourcetype precedence order update

### DIFF
--- a/charts/sck-otel/templates/_config-Agent.tpl
+++ b/charts/sck-otel/templates/_config-Agent.tpl
@@ -341,6 +341,11 @@ processors:
       - key: com.splunk.index
         from_attribute: k8s.pod.annotations.splunk.com/index
         action: upsert
+      {{- if .Values.splunkPlatform.sourcetype }}
+      - key: com.splunk.sourcetype
+        value: "{{.Values.splunkPlatform.sourcetype }}"
+        action: upsert
+      {{- end }}
   {{- include "splunk-otel-collector.resourceDetectionProcessor" . | nindent 2 }}
   resource/telemetry:
     # General resource attributes that apply to all telemetry passing through the agent.


### PR DESCRIPTION
Updated sourcetype precedence order

Order [x]: 
- Sourcetype defined via Pod annotation [1]
- Sourcetype defined via optional config param in helm chart values [2]
- K8s metadata: “kube:container:<CONTAINER_NAME>” for container logs [3]
- Sourcetype for non-container logs: "kube:*" [4]
